### PR TITLE
maxSdkVersion should not be set.

### DIFF
--- a/lib/src/main/AndroidManifest.xml
+++ b/lib/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-sdk
+
         android:maxSdkVersion="19"
         android:minSdkVersion="14"/>
 


### PR DESCRIPTION
It is causing compatibility issues for api > 19